### PR TITLE
[FEAT] VideoList Pull to Refresh 기능 추가

### DIFF
--- a/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoListViewController.swift
+++ b/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoListViewController.swift
@@ -52,6 +52,8 @@ final class VideoListViewController: BaseViewController<VideoListViewModel> {
         viewModel.fetchVideoList()
     }
     
+    private let refreshControl = UIRefreshControl()
+    
     override func setupUI() {
         super.setupUI()
         title = "모든 콘텐츠"
@@ -62,6 +64,10 @@ final class VideoListViewController: BaseViewController<VideoListViewModel> {
         view.addSubview(emptyView)
         scrollView.addSubview(containerStackView)
         [categorySegmentedControl, videoCollectionView].forEach { containerStackView.addArrangedSubview($0) }
+        
+        scrollView.refreshControl = refreshControl
+        refreshControl.addTarget(self, action: #selector(didPullToRefresh), for: .valueChanged)
+        
     }
     
     override func setupConstraints() {
@@ -92,6 +98,10 @@ final class VideoListViewController: BaseViewController<VideoListViewModel> {
             .sink { [weak self] videoItems in
                 self?.emptyView.isHidden = !videoItems.isEmpty
                 self?.applySnapshot(videoItems: videoItems)
+                
+                if self?.refreshControl.isRefreshing == true{
+                    self?.refreshControl.endRefreshing()
+                }
             }
             .store(in: &cancellables)
         
@@ -116,6 +126,10 @@ final class VideoListViewController: BaseViewController<VideoListViewModel> {
         }
         categorySegmentedControl.selectedSegmentIndex = viewModel.selectedCategoryIndex
     }
+    @objc private func didPullToRefresh() {
+        viewModel.fetchVideoList()
+    }
+    
     
     @objc
     private func categoryChanged(_ sender: UISegmentedControl) {


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
VideoList 화면에 Pull to Refresh 기능을 추가했습니다.
사용자가 리스트를 아래로 당기면 fetchVideoList()를 다시 호출하여 데이터를 갱신하도록 구현했습니다.

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->
- UIRefreshControl 추가 및 scrollView에 연결
- didPullToRefresh() 메서드 구현 → fetchVideoList() 호출 후 refresh 상태 종료
- bind 과정에서 videoList가 갱신되면 refresh 상태도 자동으로 해제되도록 처리


## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### As-Is
<!-- 작업 이전 동작하던 부분을 기재합니다 -->
**기존 로직**
- VideoList 화면에서 리스트 새로고침 기능이 없음
- 데이터 갱신은 화면 재진입 시에만 발생


**스크린샷**

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
- Pull to Refresh 제스처로 데이터 갱신 가능
- 새로고침 후 emptyView 및 snapshot 갱신 동작 확인



**스크린샷**
<img src="https://github.com/user-attachments/assets/536305cb-9e0e-41c6-9e7f-789f3f6a9f7c" width="25%" alt="Image">

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
1. 앱 실행 후 VideoList 화면으로 이동
2. 리스트를 아래로 당겨 Pull to Refresh 동작 수행
3. 새로고침 후 데이터가 정상적으로 갱신되는지 확인



## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## Additional context
<!--- [선택사항] 추가적으로 공유해야 할 사항이 있다면 기재합니다. -->

## References
<!--- [선택사항] 참고한 자료가 있다면 기재합니다. -->
