### PR TITLE
[FIX] 비디오상세 pop되더라도 재생되는 문제 해결

### DIFF
--- a/FrogHouse/FrogHouse/Source/Common/Util/AVPlayManager.swift
+++ b/FrogHouse/FrogHouse/Source/Common/Util/AVPlayManager.swift
@@ -103,6 +103,15 @@ final class AVPlayManager {
         player.seek(to: CMTime(seconds: newTime, preferredTimescale: currentItem.currentTime().timescale))
     }
     
+    func reset() {
+        player.replaceCurrentItem(with: nil)
+        isPlaying = false
+        isMuted = false
+        currentSpeed = 1.0
+        currentTime = 0
+        duration = 0
+    }
+    
     // MARK: - Observers
     private func observeCurrentItemDuration() {
         player.publisher(for: \.currentItem)

--- a/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewController.swift
+++ b/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewController.swift
@@ -46,6 +46,18 @@ final class VideoDetailViewController: BaseViewController<VideoDetailViewModel> 
         playerLayer?.frame = playerContainerView.bounds
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.play()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            viewModel.resetPlayer()
+        }
+    }
+    
     // MARK: - Setup
     override func setupLayouts() {
         super.setupLayouts()

--- a/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewModel.swift
+++ b/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewModel.swift
@@ -10,7 +10,7 @@ import Combine
 import Foundation
 
 final class VideoDetailViewModel: ObservableObject {
-    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var isPlaying: Bool = true
     @Published private(set) var isMuted: Bool = false
     @Published private(set) var currentSpeed: Float = 1.0
     @Published private(set) var endTime: String = "0:00"
@@ -36,6 +36,8 @@ final class VideoDetailViewModel: ObservableObject {
     func seekBackward() { playManager.seekBackward() }
     func seekForward() { playManager.seekForward() }
     func seek(to value: Float) { playManager.seek(to: value) }
+    func resetPlayer() { playManager.reset() }
+    func play() { playManager.play() }
     
     private func bindManager() {
         playManager.$isPlaying


### PR DESCRIPTION
- VideoDetail화면에서 pop될때 AVPlayerManager reset동작 추가

<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
<!--- 작업에 대한 간단한 설명 -->
- 비디오상세화면에서 비디오 재생 이후 pop되더라도 여전히 비디오가 재생중인 문제를 해결하기위한 작업을 진행하였습니다.

## Works made
<!-- 작업한 내용을 기재합니다. 어떤 파일이 추가되었는지, 어떤 의도로 메서드를 만들었는지, 라이브러리 추가가 왜 필요했는지 등 최대한 자세하게 작성합니다. -->

## Changes Made
<!--- 변경된 부분을 asis-tobe 형식으로 작성합니다. UI 변경이 있을 경우 반드시 모든 부분의 스크린샷을 첨부해야 하며 비즈니스 로직이 바뀌었다면 따로 적어줍니다. -->

### To-BE
<!-- 작업 이후 변경된 부분을 기재합니다. -->
**변경 로직**
``` swift
override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        viewModel.play()
    }

override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        if isMovingFromParent {
            viewModel.resetPlayer()
        }
    }
```

**영상녹화**
https://github.com/user-attachments/assets/f6ab2fde-157e-4053-9c90-34c178a790f3

## How to Test
<!--- 작업 내용을 확인하거나 테스트 할 수 있는 방법을 기재합니다.  -->
1. 특정 비디오를 클릭해 비디오 상세화면 이동 
2. 정지버튼누르지않고 비디오리스트로 이동(Navigation Pop)
3. 기존 비디오상세화면에 해당하는 비디오소리가 재생되지않는지 확인 
