### PR TITLE
[FEAT] HapticManager 유틸 추가

### DIFF
--- a/FrogHouse/FrogHouse/Source/Common/UI/SnackBar.swift
+++ b/FrogHouse/FrogHouse/Source/Common/UI/SnackBar.swift
@@ -46,7 +46,7 @@ class SnackBar: UIView {
     
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .FH.signatureGreen.color
+        label.textColor = .FH.primary.color
         label.text = style.message
         label.numberOfLines = 1
         return label
@@ -66,7 +66,7 @@ class SnackBar: UIView {
     required init?(coder: NSCoder) { fatalError() }
     
     private func setupUI() {
-        backgroundColor = .FH.backgroundBase.color
+        backgroundColor = .FH.backgroundLightGreen.color
         layer.cornerRadius = 8
         
         addSubview(contentStackView)

--- a/FrogHouse/FrogHouse/Source/Common/UI/VideoProgressView.swift
+++ b/FrogHouse/FrogHouse/Source/Common/UI/VideoProgressView.swift
@@ -11,6 +11,7 @@ final class VideoProgressView: UIView {
     let volumeSlider: UISlider = {
         let slider = UISlider()
         slider.value = 0.0
+        slider.minimumTrackTintColor = UIColor.FH.signatureGreen.color
         return slider
     }()
     

--- a/FrogHouse/FrogHouse/Source/Common/Util/HapticManager.swift
+++ b/FrogHouse/FrogHouse/Source/Common/Util/HapticManager.swift
@@ -1,0 +1,23 @@
+//
+//  HapticManager.swift
+//  FrogHouse
+//
+//  Created by SJS on 9/15/25.
+//
+
+import Foundation
+import UIKit
+
+class HapticManager {
+    static let shared = HapticManager()
+
+    func hapticNotification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+    }
+
+    func hapticImpact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.impactOccurred()
+    }
+}

--- a/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoCell.swift
+++ b/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoCell.swift
@@ -99,6 +99,7 @@ final class VideoCell: UICollectionViewCell {
         likeButton.publisher(for: .touchUpInside)
             .throttle(for: .milliseconds(500), scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
+                HapticManager.shared.hapticImpact(style: .light)
                 self?.onLikeTapped?()
             }
             .store(in: &cancellables)

--- a/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewController.swift
+++ b/FrogHouse/FrogHouse/Source/Scene/VideoList/VideoDetail/VideoDetailViewController.swift
@@ -282,12 +282,14 @@ final class VideoDetailViewController: BaseViewController<VideoDetailViewModel> 
     @objc
     private func didDoubleTapLeft() {
         viewModel.seekBackward()
+        HapticManager.shared.hapticImpact(style: .rigid)
         showFeedback("⏪ 10")
     }
     
     @objc
     private func didDoubleTapRight() {
         viewModel.seekForward()
+        HapticManager.shared.hapticImpact(style: .rigid)
         showFeedback("10 ⏩")
     }
 }


### PR DESCRIPTION
<!--- 
Pull Request 제목은 반드시 아래의 형식을 따라야 합니다.
[<Category>] <issue number> <description> (e.g. "[Feature] #123 새로운 제스쳐 추가") 
-->

## Describe
공통적으로 사용할 수 있는 햅틱 피드백 추가
hapticImpact(종류: heavy, light, meduium, rigid, soft)
<img src="https://github.com/user-attachments/assets/39a58de7-27ff-4aeb-b6cc-bc72813f65c8" width="40%" alt="Image"> <img src="https://github.com/user-attachments/assets/1b4f829a-f4fb-45e9-8922-59f1220b8832" width="30%" alt="Image">



hapticNotification(종류: warning, error, success)
<img src="https://github.com/user-attachments/assets/8c3f0c84-2d05-4186-b995-a0974232a1e9" width="40%" alt="Image">



## Works made
- `HapticManager.swift` 파일 추가
  - `hapticImpact(style:)` : Impact 피드백 제공 (light, medium, heavy, rigid, soft)
  - `hapticNotification(type:)` : Notification 피드백 제공 (success, warning, error)
- 디테일 뷰 더블탭 제스처 및 리스트 뷰 하트 버튼에 햅틱 반응을 추가
- VideoCell 수정 (하트 버튼 탭 시 HapticManager 호출하여 햅틱 반응 추가)
- VideoDetailViewController 수정 (더블탭 제스처 시 햅틱 반응 추가)


## Changes Made

### As-Is
**기존 로직**
- 공통 햅틱 유틸 없음
- 버튼/이벤트마다 직접 Generator 생성 필요

**스크린샷**

### To-BE
**변경 로직**
- 공통 `HapticManager` 유틸 추가
- HapticManager.shared`를 통해 간단히 호출 가능
- 하트 버튼 탭 → UIImpactFeedbackGenerator(style: .medium) 반응 추가
- 더블탭 제스처 → UIImpactFeedbackGenerator(style: .light) 반응 추가

**스크린샷**

## How to Test
1. 시뮬레이터가 아닌 본인 아이폰에 직접 앱을 설치.
2. 설치된 앱에서 햅틱 피드백이 오는지 체크.

(코드에서 사용하는 방법)
`HapticManager.shared.hapticImpact(style: .light)`
`HapticManager.shared.hapticNotification(type: .warning)`

## Issues Resolved
<!-- 
연관된 이슈나 다른 PR이 있다면 적어줍니다. '#123' 처럼 이슈 번호만 적지 말고, 이슈 타이틀이 같이 보일 수 있도록 bulletin list로 작성합니다.
e.g.
 - #123
 - #124
-->

## Additional context
어느 구역에 햅틱 피드백을 넣을 것인지 의논 필요.


## References
https://developer.apple.com/design/human-interface-guidelines/playing-haptics